### PR TITLE
Add installation information for Opera

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -8,8 +8,13 @@
 ![Demo](http://f.cl.ly/items/2S3a3P2a1u3r1Z1I1y3f/screenshot.png)
 
 ## Installing
+### Google Chrome
 
 You can download Daydream from the Chrome Web Store [here](https://chrome.google.com/webstore/detail/daydream/oajnmbophdhdobfpalhkfgahchpcoali).
+
+### Opera
+
+First enable Opera to install Chrome extensions [here](https://addons.opera.com/extensions/details/download-chrome-extension-9/); then you can download Daydream from the Chrome Web Store [here](https://chrome.google.com/webstore/detail/daydream/oajnmbophdhdobfpalhkfgahchpcoali).
 
 ## Developing
 


### PR DESCRIPTION
Opera extensions are exactly the same as Chrome extensions; they even use the `chrome` object.
The Chrome webstore does not allow Opera to install extensions by default, as it relies on the useragent to identify as Chrome. The extension that allows Opera to use the Chrome webstore simply changes the useragent for only that website, which allows Opera users to install any extension from the Chrome webstore.