### PR TITLE
Change the logic to calculate a CSS Selector Path.

### DIFF
--- a/lib/foreground/index.js
+++ b/lib/foreground/index.js
@@ -3,7 +3,6 @@
 * Module dependencies.
 */
 
-var cssPath = require('stevenmiller888/component-path');
 var each = require('component/each');
 var fmt  = require('yields/fmt');
 
@@ -47,6 +46,55 @@ function copyText(){
 };
 
 /**
+ * Get the index of the specified element in the same stratum and the same element name.
+ *
+ * @param {Element} element
+ * @param {String} name
+ * @return {Number} The 1..N index value.
+ */
+function getSiblingElementsIndex(element, name) {
+  var index = 1;
+  var sibling = element;
+  while((sibling = sibling.previousElementSibling)) {
+    if (sibling.nodeName.toLowerCase() === name) {
+      index++;
+    }
+  }
+  return index;
+}
+
+/**
+ * Get the selector which represents the specified element.
+ * If the argument value is not Element, this returns an empty array.
+ *
+ * @param {Node} node
+ * @return {Array} The array which has each selector name.
+ */
+function cssPath(node) {
+  var names = [];
+  if (!(node instanceof Element)) {
+    return names;
+  }
+
+  while(node.nodeType === Node.ELEMENT_NODE) {
+    var name = node.nodeName.toLowerCase();
+    if (node.id) {
+      name += '#' + node.id;
+      names.unshift(name);
+      break;
+    }
+    var index = getSiblingElementsIndex(node, name);
+    if (1 < index) {
+      name += ':nth-of-type(' + index + ')';
+    }
+    names.unshift(name);
+    node = node.parentNode;
+  }
+
+  return names;
+};
+
+/**
  * Handle.
  *
  * @param {String} event
@@ -55,7 +103,7 @@ function copyText(){
 
 function handle(event, node) {
   if (chrome && chrome.runtime) {
-    var path = cssPath(node);
+    var path = cssPath(node).join(' > ');
     var message = [event, path];
     message.push(node.value);
     chrome.runtime.sendMessage(message);


### PR DESCRIPTION
The current cssPath calculation logic generates very complex selector. Also, when I tested this extension, many wrong selectors were generated. I want to change the generation logic so that this extension generates more simple selector path.

I guess that a CSS selector based on the element hierarchy would be better than the CSS class name chains.

It would be great if you review this pull request and merge this if LGTM. Thank you! 😄 

Closes https://github.com/segmentio/daydream/issues/21
