### PR TITLE
add wait method for click and type method automatically

### DIFF
--- a/src/background/daydream.js
+++ b/src/background/daydream.js
@@ -61,11 +61,11 @@ class Daydream {
           result += `  .goto('${content}')${newLine}`
           break
         case 'click':
-          result += `  .click('${content}')${newLine}`
+          result += `  .wait('${content}')${newLine}  .click('${content}')${newLine}`
           break
         case 'type':
           const val = record[2]
-          result += `  .type('${content}', '${val}')${newLine}`
+          result += `  .wait('${content}')${newLine}  .type('${content}', '${val}')${newLine}`
           break
         case 'screenshot':
           result += `  .screenshot('${content}')${newLine}`


### PR DESCRIPTION
Following scene, input something and click search button(with id search), when result is shown, then click next page button(with id nextpage)，daydream will generate below code:

```javascript
const Nightmare = require('nightmare')
const nightmare = Nightmare({ show: true })

nightmare
  .type('#search-input', 'hello')
  .click('#search')
  .click('#nextpage')
  .end()
    .then(function (result) {
      console.log(result)
    })
    .catch(function (error) {
      console.error('Error:', error);
    });
```

Actually, something is missed and that's wait method, without wait(), nightmare will throw exception: `Unable to find element by selector: #nextpage`, because daydream not include wait. 

With this pull request code, will become:

```javascript
const Nightmare = require('nightmare')
const nightmare = Nightmare({ show: true })

nightmare
  .wait('#search-input')
  .type('#search-input', 'hello')
  .wait('#search')
  .click('#search')
  .wait('#nextpage')
  .click('#nextpage')
  .end()
    .then(function (result) {
      console.log(result)
    })
    .catch(function (error) {
      console.error('Error:', error);
    });
```

And everything will be ok.