### PR TITLE
add wait mehtod for click and type

### DIFF
--- a/src/popup/components/App.js
+++ b/src/popup/components/App.js
@@ -17,10 +17,10 @@ ${props.recording.reduce((records, record, i) => {
 
   switch (action) {
     case 'change':
-      result += `.type('${selector}', '${value}')`
+      result += `.wait('${selector}')\n.type('${selector}', '${value}')`
       break
     case 'click':
-      result += `.click('${selector}')`
+      result += `.wait('${selector}')\n.click('${selector}')`
       break
     case 'goto':
       result += `.goto('${url}')`


### PR DESCRIPTION
Following scene, input something and click search button(with id search), when result is shown, then click next page button(with id nextpage)，daydream will generate below code:

```javascript
const Nightmare = require('nightmare')
const nightmare = Nightmare({ show: true })

nightmare
.type('#search-input', 'hello')
.click('#search')
.click('#nextpage')
.end()
.then(function (result) {
  console.log(result)
})
.catch(function (error) {
  console.error('Error:', error);
});
```

Actually, something is missed and that's wait method, without wait(), nightmare will throw exception: `Unable to find element by selector: #nextpage`, because daydream not include wait. 

With this pull request code, will become:

```javascript
const Nightmare = require('nightmare')
const nightmare = Nightmare({ show: true })

nightmare
.wait('#search-input')
.type('#search-input', 'hello')
.wait('#search')
.click('#search')
.wait('#nextpage')
.click('#nextpage')
.end()
.then(function (result) {
  console.log(result)
})
.catch(function (error) {
  console.error('Error:', error);
});
```

everything will be ok.