### PR TITLE
simple implementation for handling new tab opens

### DIFF
--- a/src/background/recorder.js
+++ b/src/background/recorder.js
@@ -2,6 +2,7 @@
 export default class Recorder {
   constructor () {
     this.recording = []
+    this.lastUrl
   }
 
   start () {
@@ -23,12 +24,16 @@ export default class Recorder {
   }
 
   handleCommittedNavigation ({ transitionQualifiers, url }) {
-    if (transitionQualifiers.includes('from_address_bar')) {
+    if (transitionQualifiers.includes('from_address_bar') || url === this.lastUrl) {
       this.handleMessage({ action: 'goto', url })
     }
   }
 
   handleMessage (message) {
-    this.recording.push(message)
+    if (message.action === 'url') {
+      this.lastUrl = message.value
+    } else {
+      this.recording.push(message)
+    }
   }
 }

--- a/src/content-scripts/index.js
+++ b/src/content-scripts/index.js
@@ -12,6 +12,13 @@ class EventRecorder {
   }
 
   handleEvent (e) {
+    if (e.target.href) {
+      chrome.runtime.sendMessage({
+        action: 'url',
+        value: e.target.href
+      })
+    }
+
     chrome.runtime.sendMessage({
       selector: selector.getSelector(e.target),
       value: e.target.value,


### PR DESCRIPTION
This contains a very simple initial implementation to attempt to support moving to a new tab as part of the "recording" for Daydream (issue #31). 

The is only a initial attempt because while this is a useful feature, I think it's up for discussion about how this should be handled properly. So for example when moving to a new tab by clicking a link (which is what this PR is handling) do actions get recorded in both tabs, should one take priority.

CC @stevenmiller888 @Jalalx @Cleop